### PR TITLE
Updated versions of pax exam and pax runner

### DIFF
--- a/lesson-cxf/src/test/java/org/ops4j/pax/exam/learn/cxf/CXFLaboratories.java
+++ b/lesson-cxf/src/test/java/org/ops4j/pax/exam/learn/cxf/CXFLaboratories.java
@@ -31,7 +31,7 @@ import org.ops4j.pax.exam.TestProbeBuilder;
 import org.ops4j.pax.exam.apart.DoSomething;
 import org.ops4j.pax.exam.junit.Configuration;
 import org.ops4j.pax.exam.junit.JUnit4TestRunner;
-import org.ops4j.pax.exam.spi.container.PaxExamRuntime;
+import org.ops4j.pax.exam.spi.PaxExamRuntime;
 import org.ops4j.pax.exam.testforge.BundlesInState;
 import org.ops4j.pax.exam.testforge.SingleClassProvider;
 import org.osgi.framework.Bundle;

--- a/lesson-junit/src/test/java/org/ops4j/pax/exam/lesson3/LessonTest.java
+++ b/lesson-junit/src/test/java/org/ops4j/pax/exam/lesson3/LessonTest.java
@@ -31,8 +31,8 @@ import org.ops4j.pax.exam.spi.reactors.AllConfinedStagedReactorFactory;
 import org.ops4j.pax.exam.testforge.SingleClassProvider;
 import org.slf4j.LoggerFactory;
 
-import static org.ops4j.pax.exam.spi.container.PaxExamRuntime.createTestSystem;
-import static org.ops4j.pax.exam.spi.container.PaxExamRuntime.createContainer;
+import static org.ops4j.pax.exam.spi.PaxExamRuntime.createTestSystem;
+import static org.ops4j.pax.exam.spi.PaxExamRuntime.createContainer;
 
 import static org.hamcrest.core.Is.*;
 import static org.hamcrest.core.IsNull.*;

--- a/lesson-plumbing/src/test/java/org/ops4j/pax/exam/lesson1/LessonTest.java
+++ b/lesson-plumbing/src/test/java/org/ops4j/pax/exam/lesson1/LessonTest.java
@@ -26,7 +26,7 @@ import org.ops4j.pax.exam.TestProbeBuilder;
 import org.ops4j.pax.exam.TestProbeProvider;
 
 import static org.ops4j.pax.exam.CoreOptions.*;
-import static org.ops4j.pax.exam.spi.container.PaxExamRuntime.*;
+import static org.ops4j.pax.exam.spi.PaxExamRuntime.*;
 
 /**
  * This is the very first Pax Exam Lesson.
@@ -120,7 +120,7 @@ public class LessonTest {
         throws IOException
     {
     	
-        TestProbeBuilder probe = system.createProbe( new Properties() );
+        TestProbeBuilder probe = system.createProbe();
         probe.addTest( Probe.class, "probe1" );
 
         probe.addTest( Probe.class, "probe2" );

--- a/lesson-porcelain/src/test/java/org/ops4j/pax/exam/lesson2/LessonTest.java
+++ b/lesson-porcelain/src/test/java/org/ops4j/pax/exam/lesson2/LessonTest.java
@@ -15,7 +15,7 @@
  */
 package org.ops4j.pax.exam.lesson2;
 
-import static org.ops4j.pax.exam.spi.container.PaxExamRuntime.*;
+import static org.ops4j.pax.exam.spi.PaxExamRuntime.*;
 import static org.ops4j.pax.exam.CoreOptions.*;
 
 import java.io.IOException;
@@ -30,7 +30,7 @@ import org.ops4j.pax.exam.TestProbeProvider;
 import org.ops4j.pax.exam.spi.ExxamReactor;
 import org.ops4j.pax.exam.spi.StagedExamReactor;
 import org.ops4j.pax.exam.spi.StagedExamReactorFactory;
-import org.ops4j.pax.exam.spi.driversupport.DefaultExamReactor;
+import org.ops4j.pax.exam.spi.DefaultExamReactor;
 import org.ops4j.pax.exam.spi.reactors.EagerSingleStagedReactorFactory;
 
 /**
@@ -88,7 +88,7 @@ public class LessonTest {
     private TestProbeProvider makeProbe(ExamSystem system)
         throws IOException
     {
-        TestProbeBuilder probe = system.createProbe( new Properties() );
+        TestProbeBuilder probe = system.createProbe();
         probe.addTest(
             Probe.class, "probe1"
         );

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <properties>
         <paxexamversion>2.2.0</paxexamversion>
-        <paxrunnerversion>1.7.4</paxrunnerversion>
+        <paxrunnerversion>1.7.6</paxrunnerversion>
         <paxurlversion>1.3.3</paxurlversion>
         <felixversion>3.2.2</felixversion>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <name>Pax Exam Strategy Guide</name>
 
     <properties>
-        <paxexamversion>2.1.0</paxexamversion>
+        <paxexamversion>2.2.0</paxexamversion>
         <paxrunnerversion>1.7.4</paxrunnerversion>
         <paxurlversion>1.3.3</paxurlversion>
         <felixversion>3.2.2</felixversion>


### PR DESCRIPTION
I did some minor updates:
 Updated pax exam version from 2.1 to 2.2. 
 Updated pax runner version from 1.7.3 to 1.7.6

Info:
 I did not update pax exam to 2.3 because the tests did not run successfully with version 2.3. I don't have enough experience to fix that so I just left it.
